### PR TITLE
Improve haiku generation handling

### DIFF
--- a/src/app/api/haiku/route.ts
+++ b/src/app/api/haiku/route.ts
@@ -4,12 +4,17 @@ import { englishToHaiku } from "@/lib/haiku";
 export async function POST(req: Request) {
   try {
     const { text } = await req.json();
+    if (typeof text !== "string" || !text.trim() || text.length > 200) {
+      return NextResponse.json(
+        { error: "Invalid text" },
+        { status: 400 },
+      );
+    }
     const haiku = await englishToHaiku(text);
     return NextResponse.json({ haiku });
   } catch (err) {
-    return NextResponse.json(
-      { error: (err as Error).message },
-      { status: 500 },
-    );
+    const message = (err as Error).message;
+    const status = message.includes("OpenAI API error") ? 502 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }


### PR DESCRIPTION
## Summary
- validate OpenAI API key and parse responses more robustly
- add client-side loading, error, and input validation for haiku generation
- validate API input and return appropriate error statuses

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c24f5f1b388325b68f438ab32f2116