### PR TITLE
Fix OpenAI request for haiku generation

### DIFF
--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -10,7 +10,7 @@ export async function englishToHaiku(text: string): Promise<HaikuResult> {
   }
   const model = process.env.OPENAI_MODEL ?? "gpt-4o-mini";
 
-  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+  const res = await fetch("https://api.openai.com/v1/responses", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -20,7 +20,7 @@ export async function englishToHaiku(text: string): Promise<HaikuResult> {
       model,
       temperature: 0.8,
       response_format: { type: "json_object" },
-      messages: [
+      input: [
         {
           role: "system",
           content:
@@ -39,7 +39,9 @@ export async function englishToHaiku(text: string): Promise<HaikuResult> {
   }
 
   const data = await res.json();
-  const content = data.choices?.[0]?.message?.content;
+  const content =
+    data.output?.[0]?.content?.[0]?.text ||
+    data.choices?.[0]?.message?.content;
   if (!content) {
     throw new Error("Invalid OpenAI response format");
   }


### PR DESCRIPTION
## Summary
- switch to OpenAI Responses API for haiku generation
- parse response text from new output format

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c26eb4f25c8325a8b8b5cb5e622003