### PR TITLE
Surface OpenAI API error messages in haiku endpoint

### DIFF
--- a/src/app/api/haiku/route.ts
+++ b/src/app/api/haiku/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
     const haiku = await englishToHaiku(text);
     return NextResponse.json({ haiku });
   } catch (err) {
-    const message = (err as Error).message;
+    const message = err instanceof Error ? err.message : String(err);
     const status = message.includes("OpenAI API error") ? 502 : 500;
     return NextResponse.json({ error: message }, { status });
   }

--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -38,7 +38,17 @@ export async function englishToHaiku(text: string): Promise<HaikuResult> {
   );
 
   if (!res.ok) {
-    throw new Error(`OpenAI API error: ${res.status} ${res.statusText}`);
+    let message = `OpenAI API error: ${res.status} ${res.statusText}`;
+    try {
+      const err = await res.json();
+      const apiMessage = err?.error?.message;
+      if (apiMessage) {
+        message += ` - ${apiMessage}`;
+      }
+    } catch {
+      // ignore JSON parse errors from error responses
+    }
+    throw new Error(message);
   }
 
   const data = await res.json();


### PR DESCRIPTION
## Summary
- Include OpenAI's `error.message` in thrown errors from `englishToHaiku`
- Return the same detailed error message from `/api/haiku` responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2725df16083259f6381b335ca0308