### PR TITLE
Force Node runtime for haiku API and add debug endpoints

### DIFF
--- a/src/app/api/debug-env/route.ts
+++ b/src/app/api/debug-env/route.ts
@@ -1,0 +1,7 @@
+export const runtime = "nodejs";
+export async function GET() {
+  return Response.json({
+    hasKey: !!process.env.OPENAI_API_KEY,
+    env: process.env.VERCEL_ENV || "unknown",
+  });
+}

--- a/src/app/api/hello-openai/route.ts
+++ b/src/app/api/hello-openai/route.ts
@@ -1,0 +1,13 @@
+export const runtime = "nodejs";
+export async function GET() {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) return new Response("no key", { status: 500 });
+
+  const r = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "gpt-4o-mini", input: "Say 'pong'.", max_output_tokens: 8 }),
+  });
+  const txt = await r.text();
+  return new Response(txt, { status: r.status, headers: { "Content-Type": "application/json" } });
+}


### PR DESCRIPTION
## Summary
- ensure `/api/haiku` runs on the Node.js runtime and returns raw upstream errors for easier debugging
- add `/api/debug-env` route to verify environment setup
- add `/api/hello-openai` route to check connectivity to OpenAI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c284df9918832584e504efce8bf91d