### PR TITLE
fix: update response format param

### DIFF
--- a/src/app/api/haiku/route.ts
+++ b/src/app/api/haiku/route.ts
@@ -38,28 +38,30 @@ export async function POST(req: NextRequest) {
         input: `Generate a 3-line haiku in Japanese (5-7-5) about: ${text}\nProvide an English translation. Return JSON with keys 'ja' and 'en' (arrays of three strings).`,
         max_output_tokens: 120,
         temperature: 0.7,
-        response_format: {
-          type: "json_schema",
-          json_schema: {
-            name: "haiku_schema",
-            schema: {
-              type: "object",
-              properties: {
-                ja: {
-                  type: "array",
-                  items: { type: "string" },
-                  minItems: 3,
-                  maxItems: 3,
+        text: {
+          format: {
+            type: "json_schema",
+            json_schema: {
+              name: "haiku_schema",
+              schema: {
+                type: "object",
+                properties: {
+                  ja: {
+                    type: "array",
+                    items: { type: "string" },
+                    minItems: 3,
+                    maxItems: 3,
+                  },
+                  en: {
+                    type: "array",
+                    items: { type: "string" },
+                    minItems: 3,
+                    maxItems: 3,
+                  },
                 },
-                en: {
-                  type: "array",
-                  items: { type: "string" },
-                  minItems: 3,
-                  maxItems: 3,
-                },
+                required: ["ja", "en"],
+                additionalProperties: false,
               },
-              required: ["ja", "en"],
-              additionalProperties: false,
             },
           },
         },

--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -20,18 +20,20 @@ export async function englishToHaiku(text: string): Promise<HaikuResult> {
       model,
       temperature: 0.8,
       max_output_tokens: 300,
-      response_format: {
-        type: "json_schema",
-        json_schema: {
-          name: "haiku",
-          strict: true,
-          schema: {
-            type: "object",
-            additionalProperties: false,
-            required: ["ja", "en"],
-            properties: {
-              ja: { type: "array", items: { type: "string" } },
-              en: { type: "array", items: { type: "string" } },
+      text: {
+        format: {
+          type: "json_schema",
+          json_schema: {
+            name: "haiku",
+            strict: true,
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              required: ["ja", "en"],
+              properties: {
+                ja: { type: "array", items: { type: "string" } },
+                en: { type: "array", items: { type: "string" } },
+              },
             },
           },
         },


### PR DESCRIPTION
## Summary
- replace deprecated `response_format` with `text.format` in haiku API route
- adjust haiku library to use new Responses API text formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`: Please check your network connection.)*

------
https://chatgpt.com/codex/tasks/task_e_68c291db19888325b37836697af03158