### PR TITLE
Use text.format for OpenAI Responses API

### DIFF
--- a/src/app/api/haiku/route.ts
+++ b/src/app/api/haiku/route.ts
@@ -41,27 +41,26 @@ export async function POST(req: NextRequest) {
         text: {
           format: {
             type: "json_schema",
-            json_schema: {
-              name: "haiku_schema",
-              schema: {
-                type: "object",
-                properties: {
-                  ja: {
-                    type: "array",
-                    items: { type: "string" },
-                    minItems: 3,
-                    maxItems: 3,
-                  },
-                  en: {
-                    type: "array",
-                    items: { type: "string" },
-                    minItems: 3,
-                    maxItems: 3,
-                  },
+            name: "haiku_schema",
+            strict: true,
+            schema: {
+              type: "object",
+              properties: {
+                ja: {
+                  type: "array",
+                  items: { type: "string" },
+                  minItems: 3,
+                  maxItems: 3,
                 },
-                required: ["ja", "en"],
-                additionalProperties: false,
+                en: {
+                  type: "array",
+                  items: { type: "string" },
+                  minItems: 3,
+                  maxItems: 3,
+                },
               },
+              required: ["ja", "en"],
+              additionalProperties: false,
             },
           },
         },

--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -23,17 +23,15 @@ export async function englishToHaiku(text: string): Promise<HaikuResult> {
       text: {
         format: {
           type: "json_schema",
-          json_schema: {
-            name: "haiku",
-            strict: true,
-            schema: {
-              type: "object",
-              additionalProperties: false,
-              required: ["ja", "en"],
-              properties: {
-                ja: { type: "array", items: { type: "string" } },
-                en: { type: "array", items: { type: "string" } },
-              },
+          name: "haiku",
+          strict: true,
+          schema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["ja", "en"],
+            properties: {
+              ja: { type: "array", items: { type: "string" } },
+              en: { type: "array", items: { type: "string" } },
             },
           },
         },


### PR DESCRIPTION
## Summary
- fix structured output requests by using `text.format` instead of deprecated `response_format`
- define JSON schema inline with name and strict options for haiku generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c29578246c8325a367e795005d3f8c