### PR TITLE
Fix haiku API response shape

### DIFF
--- a/src/app/api/haiku/route.ts
+++ b/src/app/api/haiku/route.ts
@@ -7,7 +7,7 @@ export const runtime = "nodejs";
 /**
  * POST /api/haiku
  * Expects: { text: string }
- * Returns: { ja: string[]; en: string[] }
+ * Returns: { haiku: { ja: string[]; en: string[] } }
  */
 export async function POST(req: NextRequest) {
   try {
@@ -20,16 +20,10 @@ export async function POST(req: NextRequest) {
 
     const haiku = await englishToHaiku(text);
 
-    return new Response(JSON.stringify(haiku), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return Response.json({ haiku });
   } catch (err: unknown) {
     console.error("haiku route crashed:", err);
     const message = err instanceof Error ? err.message : String(err);
-    return new Response(JSON.stringify({ error: message }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return Response.json({ error: message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- wrap haiku API response in an object using `Response.json`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c3972f36848325be58bde108e428fd