### PR TITLE
Restore OpenAI project requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Next.js (React + TypeScript + Tailwind CSS) を使った簡易ツール。日本
    ```
 
 ### 手順例
-1. 上記の `.env.local` を作成して API キーを設定。
+1. 上記の `.env.local` を作成して API キーとプロジェクト ID を設定。
 2. 開発サーバーを起動。
    ```bash
    npm run dev

--- a/src/app/api/hello-openai/route.ts
+++ b/src/app/api/hello-openai/route.ts
@@ -2,8 +2,7 @@ export const runtime = "nodejs";
 export async function GET() {
   const key = process.env.OPENAI_API_KEY;
   const project = process.env.OPENAI_PROJECT;
-  if (!key || !project)
-    return new Response("missing credentials", { status: 500 });
+  if (!key || !project) return new Response("missing credentials", { status: 500 });
 
   const r = await fetch("https://api.openai.com/v1/responses", {
     method: "POST",


### PR DESCRIPTION
## Summary
- ensure OpenAI requests include project ID header
- document required `OPENAI_PROJECT` in env template and README
- check sample API route for both API key and project ID

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c792158ccc8325958c5ccf01653c81