### PR TITLE
Fix Responses API JSON schema payload

### DIFF
--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -24,44 +24,46 @@ export async function englishToHaiku(
       temperature: 0.8,
       max_output_tokens: 300,
       text: {
-        format: "json_schema",
-        json_schema: {
-          name: "haiku",
-          schema: {
-            type: "object",
-            additionalProperties: false,
-            required: ["ja", "en"],
-            properties: {
-              ja: {
-                type: "array",
-                minItems: 3,
-                maxItems: 3,
-                prefixItems: [
-                  {
-                    type: "string",
-                    minLength: 5,
-                    maxLength: 5,
-                    description: "Japanese haiku first line (5 characters)",
-                  },
-                  {
-                    type: "string",
-                    minLength: 7,
-                    maxLength: 7,
-                    description: "Japanese haiku second line (7 characters)",
-                  },
-                  {
-                    type: "string",
-                    minLength: 5,
-                    maxLength: 5,
-                    description: "Japanese haiku third line (5 characters)",
-                  },
-                ],
-              },
-              en: {
-                type: "array",
-                minItems: 3,
-                maxItems: 3,
-                items: { type: "string" },
+        format: {
+          type: "json_schema",
+          json_schema: {
+            name: "haiku",
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              required: ["ja", "en"],
+              properties: {
+                ja: {
+                  type: "array",
+                  minItems: 3,
+                  maxItems: 3,
+                  prefixItems: [
+                    {
+                      type: "string",
+                      minLength: 5,
+                      maxLength: 5,
+                      description: "Japanese haiku first line (5 characters)",
+                    },
+                    {
+                      type: "string",
+                      minLength: 7,
+                      maxLength: 7,
+                      description: "Japanese haiku second line (7 characters)",
+                    },
+                    {
+                      type: "string",
+                      minLength: 5,
+                      maxLength: 5,
+                      description: "Japanese haiku third line (5 characters)",
+                    },
+                  ],
+                },
+                en: {
+                  type: "array",
+                  minItems: 3,
+                  maxItems: 3,
+                  items: { type: "string" },
+                },
               },
             },
           },


### PR DESCRIPTION
## Summary
- update the haiku request payload to nest the JSON schema under `text.format`
- keep the existing schema constraints while complying with the latest Responses API field names

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8d0189bf08325bb82a284f5551c60