### PR TITLE
Fix OpenAI text format schema name placement

### DIFF
--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -26,8 +26,8 @@ export async function englishToHaiku(
       text: {
         format: {
           type: "json_schema",
+          name: "haiku",
           json_schema: {
-            name: "haiku",
             schema: {
               type: "object",
               additionalProperties: false,


### PR DESCRIPTION
## Summary
- include the `name` property directly on the `text.format` object sent to the OpenAI Responses API so requests are accepted again

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8d162a4d083258e3a407343f4aad0