### PR TITLE
Ensure JSON schema payload includes schema name

### DIFF
--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -26,6 +26,7 @@ export async function englishToHaiku(
       text: {
         format: {
           type: "json_schema",
+          name: "haiku",
           json_schema: {
             name: "haiku",
             schema: {


### PR DESCRIPTION
## Summary
- include the schema name within the `json_schema` payload to satisfy the Responses API requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d162a4d083258e3a407343f4aad0