### PR TITLE
Fix text.format schema placement

### DIFF
--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -26,44 +26,42 @@ export async function englishToHaiku(
       text: {
         format: {
           type: "json_schema",
-          json_schema: {
-            name: "haiku",
-            schema: {
-              type: "object",
-              additionalProperties: false,
-              required: ["ja", "en"],
-              properties: {
-                ja: {
-                  type: "array",
-                  minItems: 3,
-                  maxItems: 3,
-                  prefixItems: [
-                    {
-                      type: "string",
-                      minLength: 5,
-                      maxLength: 5,
-                      description: "Japanese haiku first line (5 characters)",
-                    },
-                    {
-                      type: "string",
-                      minLength: 7,
-                      maxLength: 7,
-                      description: "Japanese haiku second line (7 characters)",
-                    },
-                    {
-                      type: "string",
-                      minLength: 5,
-                      maxLength: 5,
-                      description: "Japanese haiku third line (5 characters)",
-                    },
-                  ],
-                },
-                en: {
-                  type: "array",
-                  minItems: 3,
-                  maxItems: 3,
-                  items: { type: "string" },
-                },
+          name: "haiku",
+          schema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["ja", "en"],
+            properties: {
+              ja: {
+                type: "array",
+                minItems: 3,
+                maxItems: 3,
+                prefixItems: [
+                  {
+                    type: "string",
+                    minLength: 5,
+                    maxLength: 5,
+                    description: "Japanese haiku first line (5 characters)",
+                  },
+                  {
+                    type: "string",
+                    minLength: 7,
+                    maxLength: 7,
+                    description: "Japanese haiku second line (7 characters)",
+                  },
+                  {
+                    type: "string",
+                    minLength: 5,
+                    maxLength: 5,
+                    description: "Japanese haiku third line (5 characters)",
+                  },
+                ],
+              },
+              en: {
+                type: "array",
+                minItems: 3,
+                maxItems: 3,
+                items: { type: "string" },
               },
             },
           },


### PR DESCRIPTION
## Summary
- move the JSON schema definition directly under `text.format` so the Responses API sees the required `name`
- keep the strict haiku schema (5-7-5 Japanese lines with translations) unchanged while relocating it to the new field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8d162a4d083258e3a407343f4aad0