### PR TITLE
Fix OpenAI haiku schema request parameter

### DIFF
--- a/src/lib/haiku.ts
+++ b/src/lib/haiku.ts
@@ -33,8 +33,8 @@ export async function englishToHaiku(
       model,
       temperature: 0.8,
       max_output_tokens: 300,
-      response_format: {
-        type: "json_schema",
+      text: {
+        format: "json_schema",
         json_schema: {
           name: "haiku",
           schema: {


### PR DESCRIPTION
## Summary
- update the OpenAI Responses API payload to use the new text.format field for the haiku schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8dc3d49808325a16fb5488b7cd387